### PR TITLE
fix: align devin_client with v3 API — fix 403 + terminal statuses + structured output

### DIFF
--- a/scripts/devin_client.py
+++ b/scripts/devin_client.py
@@ -43,6 +43,18 @@ def _validate_config() -> None:
             f"Missing required environment variable(s): {', '.join(missing)}. "
             "Check your GitHub Actions secrets configuration."
         )
+
+    # Guard against legacy API keys — v3 endpoints require service-user
+    # tokens which start with "cog_".
+    if DEVIN_SERVICE_TOKEN.startswith(("apk_", "apk_user_")):
+        raise RuntimeError(
+            "DEVIN_SERVICE_TOKEN appears to be a legacy API key "
+            f"(starts with '{DEVIN_SERVICE_TOKEN[:4]}…'). "
+            "The v3 API requires a service-user token (starts with 'cog_'). "
+            "Create a service user in Devin Settings → Service users and use "
+            "its token instead."
+        )
+
     # Masked diagnostics — never log the full token.
     token_preview = DEVIN_SERVICE_TOKEN[:4] + "…" if len(DEVIN_SERVICE_TOKEN) > 4 else "(short)"
     logger.info(


### PR DESCRIPTION
## Summary

Fixes multiple bugs in `scripts/devin_client.py` that prevent the triage flow from working correctly with the Devin v3 API.

**Changes:**

1. **Wrong terminal statuses** — The polling loop checked for `{"finished", "stopped", "failed", "error"}`, but the v3 API `status` field uses `exit`, `error`, `suspended` (not `finished`/`stopped`/`failed`). `finished` is a value on the *separate* `status_detail` field. Polling would never detect completion and always time out.

2. **Missing `structured_output_schema`** — The v3 API supports returning validated structured JSON via `structured_output`, but only when a JSON schema is provided in the create request. Without it, the field is always `null`. Now passes the triage schema so Devin returns the expected object directly.

3. **Output extraction** — Previously did `data.get("structured_output") or ...` which treated the field as a string. Now handles it as a dict (which is what the API returns when a schema is provided) and returns it directly, falling back to text parsing.

4. **Legacy API key detection** — Adds early validation in `_validate_config()` to detect legacy API keys (starting with `apk_` or `apk_user_`) and raise a clear error directing the user to create a service user with a `cog_` token. Legacy keys return 403 on v3 endpoints.

**⚠️ About the 403 Forbidden error:**

The most likely cause is **using a legacy API key** (`apk_*`) as the `DEVIN_SERVICE_TOKEN`. The v3 API requires a service-user token (starts with `cog_`). Legacy API keys will authenticate on some endpoints but return 403 on others.

**To fix:** Go to **Devin Settings → Service users**, create a service user with the "Member" role, and use its `cog_`-prefixed token as `DEVIN_SERVICE_TOKEN`.

If you're already using a `cog_` token and still seeing 403, verify that:
- The `DEVIN_ORG_ID` matches your actual org ID (visible in Settings → Organization details)
- The service user has at least the "Member" role (Teams orgs) or a role with `ViewOrgSessions` + `ManageOrgSessions` permissions (Enterprise orgs)

## Review & Testing Checklist for Human

- [ ] **Verify your token type**: Confirm `DEVIN_SERVICE_TOKEN` starts with `cog_`, not `apk_`. This is the most likely cause of the 403.
- [ ] **Verify `DEVIN_ORG_ID`**: Confirm the value matches what's shown in Devin Settings → Organization details.
- [ ] **Validate terminal status values against live API**: The new `_TERMINAL_STATUSES` and `_TERMINAL_DETAILS` sets are based on the current v3 API docs. These have not been tested against the live API — verify they match actual responses after the auth fix.
- [ ] **Test `suspended` as terminal**: This PR treats `suspended` sessions as terminal (stops polling). If you expect sessions to be resumed after suspension, this behavior may need adjustment.
- [ ] **End-to-end test**: After fixing auth, open a test issue and verify the full flow: session creation → polling → structured output extraction → triage comment posted.

### Notes
- These changes are based entirely on the [Devin v3 API docs](https://docs.devin.ai/api-reference/v3/sessions/post-organizations-sessions) and have **not been tested against the live API**. There is risk that the structured output schema behavior or terminal status values don't match the live API exactly.
- The `_triage_schema` is defined as a local variable inside `triage_issue()` — works fine but could be hoisted to module level if preferred.
- The `create_fix_task` function still has TODO comments for additional payload fields (`repository`, `branch`). These may need attention separately.

Link to Devin session: https://app.devin.ai/sessions/0e7d69f26584443fa557a121a86470d3
Requested by: @colepa